### PR TITLE
Node group name arguments (node_group_name and node_group_role_name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | kubernetes\_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | string | `"null"` | no |
 | max\_size | Maximum number of worker nodes | number | n/a | yes |
 | min\_size | Minimum number of worker nodes | number | n/a | yes |
+| node\_group\_name | The name of the cluster node group. | string | <cluster_name>-<random value> | no |
+| node\_group\_role\_name | The name of the cluster node group role. | string | <cluster_name>-<random value> | no |
 | node\_role\_arn | IAM role arn that will be used by managed node group | string | `""` | no |
 | source\_security\_group\_ids | Set of EC2 Security Group IDs to allow SSH access \(port 22\) from on the worker nodes. If you specify `ec2\_ssh\_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet \(0.0.0.0/0\) | list(string) | `[]` | no |
 | subnet\_ids | A list of subnet IDs to launch resources in | list(string) | n/a | yes |

--- a/examples/single-named-node-group/main.tf
+++ b/examples/single-named-node-group/main.tf
@@ -1,0 +1,115 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+#####
+# VPC and subnets
+#####
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.21.0"
+
+  name = "simple-vpc"
+
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+
+  enable_dns_hostnames   = true
+  enable_dns_support     = true
+  enable_nat_gateway     = true
+  enable_vpn_gateway     = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+  tags = {
+    "kubernetes.io/cluster/eks" = "shared",
+    Environment                 = "test"
+  }
+}
+
+#####
+# EKS Cluster
+#####
+
+resource "aws_eks_cluster" "cluster" {
+  enabled_cluster_log_types = []
+  name                      = "eks"
+  role_arn                  = aws_iam_role.cluster.arn
+  version                   = "1.14"
+
+  vpc_config {
+    subnet_ids              = flatten([module.vpc.public_subnets, module.vpc.private_subnets])
+    security_group_ids      = []
+    endpoint_private_access = "true"
+    endpoint_public_access  = "true"
+  }
+}
+
+resource "aws_iam_role" "cluster" {
+  name = "eks-cluster-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+#####
+# EKS Node Group
+#####
+module "eks-node-group" {
+  source = "../../"
+
+  node_group_name      = "example-nodegroup"
+  node_group_role_name = "example-nodegroup"
+
+  enabled      = true
+  cluster_name = aws_eks_cluster.cluster.id
+
+  subnet_ids = flatten([module.vpc.private_subnets])
+
+  desired_size = 1
+  min_size     = 1
+  max_size     = 1
+
+  ec2_ssh_key = "eks-test"
+
+  kubernetes_labels = {
+    lifecycle = "OnDemand"
+  }
+
+  tags = {
+    Environment = "test"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "random_id" "main" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && var.node_group_name == "" ? 1 : 0
 
   byte_length = 4
 
@@ -21,7 +21,7 @@ resource "aws_eks_node_group" "main" {
   count = var.enabled ? 1 : 0
 
   cluster_name    = var.cluster_name
-  node_group_name = join("-", [var.cluster_name, random_id.main[0].hex])
+  node_group_name = var.node_group_name == "" ? join("-", [var.cluster_name, random_id.main[0].hex]) : var.node_group_name
   node_role_arn   = var.node_role_arn == "" ? join("", aws_iam_role.main.*.arn) : var.node_role_arn
 
   subnet_ids = var.subnet_ids
@@ -59,7 +59,7 @@ resource "aws_eks_node_group" "main" {
 resource "aws_iam_role" "main" {
   count = var.enabled && var.create_iam_role ? 1 : 0
 
-  name = "${var.cluster_name}-managed-group-node"
+  name = var.node_group_role_name == "" ? "${var.cluster_name}-managed-group-node" : var.node_group_role_name
 
   assume_role_policy = <<EOF
 {

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,14 @@ variable "create_iam_role" {
   default     = true
 }
 
+variable "node_group_name" {
+  type        = string
+  description = "The name of the cluster node group. Defaults to <cluster_name>-<random value>"
+  default     = ""
+}
+
+variable "node_group_role_name" {
+  type        = string
+  description = "The name of the cluster node group role. Defaults to <cluster_name>-managed-group-node"
+  default     = ""
+}


### PR DESCRIPTION
# Description

This PR adds two arguments, node_group_name and node_group_role_name, to overrider the default names of the aws_eks_node_group and aws_iam_role resources. This will assist our operational teams with visual identification of these resources, where in some cases tags do not provide enough differentiation.
