### PR TITLE
Lock minimum version of provider and add force_update_version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.1.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.29.0
+  rev: v1.30.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ This module will create EKS managed Node Group that will join your existing Kube
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master` branch.
+Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
 ```hcl
 module "eks-node-group" {
   source = "umotif-public/eks-node-group/aws"
-  version = "~> 1.0.0"
+  version = "~> 2.0.0"
 
   enabled      = true
   cluster_name = aws_eks_cluster.cluster.id
@@ -32,6 +32,8 @@ module "eks-node-group" {
   kubernetes_labels = {
     lifecycle = "OnDemand"
   }
+
+  force_update_version = true
 
   tags = {
     Environment = "test"
@@ -55,13 +57,15 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| aws | ~> 2.63 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 2.63 |
 | random | n/a |
 
 ## Inputs
@@ -76,6 +80,7 @@ No requirements.
 | disk\_size | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | `number` | `20` | no |
 | ec2\_ssh\_key | SSH key name that should be used to access the worker nodes | `string` | `null` | no |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
+| force\_update\_version | Force version update if existing pods are unable to be drained due to a pod disruption budget issue. | `bool` | `false` | no |
 | instance\_types | Set of instance types associated with the EKS Node Group. Defaults to ["t3.medium"]. Terraform will only perform drift detection if a configuration value is provided | `list(string)` | <pre>[<br>  "t3.medium"<br>]</pre> | no |
 | kubernetes\_labels | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | `map(string)` | `{}` | no |
 | kubernetes\_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,8 @@ resource "aws_eks_node_group" "main" {
   release_version = var.ami_release_version
   version         = var.kubernetes_version
 
+  force_update_version = var.force_update_version
+
   tags = var.tags
 
   scaling_config {

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,9 @@ variable "node_group_role_name" {
   description = "The name of the cluster node group role. Defaults to <cluster_name>-managed-group-node"
   default     = ""
 }
+
+variable "force_update_version" {
+  type        = bool
+  description = "Force version update if existing pods are unable to be drained due to a pod disruption budget issue."
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    aws = "~> 2.63"
+  }
+}


### PR DESCRIPTION
# Description

- lock minimum version of AWS provider to `~> 2.63`
- add support for force_update_version argument

This will be part of 2.0.0 release