### PR TITLE
Add support for launch template and tf 0.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.31.0
+  rev: v1.36.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -3,20 +3,19 @@ Terraform module to provision EKS Managed Node Group
 
 ## Resources created
 
-This module will create EKS managed Node Group that will join your existing Kubernetes cluster.
+This module will create EKS managed Node Group that will join your existing Kubernetes cluster. It supports use of launch template which will allow you to further enhance and modify worker nodes.
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
+Terraform 0.12. Pin module version to `~> v3.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
 ```hcl
 module "eks-node-group" {
   source = "umotif-public/eks-node-group/aws"
-  version = "~> 2.0.0"
+  version = "~> 3.0.0"
 
-  enabled      = true
   cluster_name = aws_eks_cluster.cluster.id
 
   subnet_ids = ["subnet-1","subnet-2","subnet-3"]
@@ -43,12 +42,14 @@ module "eks-node-group" {
 
 ## Assumptions
 
-Module is to be used with Terraform > 0.12.
+Module is to be used with Terraform > 0.13. Fully working with Terraform 0.12 as well.
 
 ## Examples
 
 * [EKS Node Group- single](https://github.com/umotif-public/terraform-aws-eks-node-group/tree/master/examples/single-node-group)
 * [EKS Node Group- multiple az setup](https://github.com/umotif-public/terraform-aws-eks-node-group/tree/master/examples/multiaz-node-group)
+* [EKS Node Group- single named node group](https://github.com/umotif-public/terraform-aws-eks-node-group/tree/master/examples/single-named-node-group)
+* [EKS Node Group- single with launch template](https://github.com/umotif-public/terraform-aws-eks-node-group/tree/master/examples/single-node-group-with-launch-template)
 
 ## Authors
 

--- a/examples/multiaz-node-group/main.tf
+++ b/examples/multiaz-node-group/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 #####
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.21.0"
+  version = "2.48.0"
 
   name = "simple-vpc"
 
@@ -46,7 +46,7 @@ resource "aws_eks_cluster" "cluster" {
   enabled_cluster_log_types = []
   name                      = "eks"
   role_arn                  = aws_iam_role.cluster.arn
-  version                   = "1.14"
+  version                   = "1.17"
 
   vpc_config {
     subnet_ids              = flatten([module.vpc.public_subnets, module.vpc.private_subnets])
@@ -130,7 +130,6 @@ resource "aws_iam_role_policy_attachment" "main_AmazonEC2ContainerRegistryReadOn
 module "eks-node-group-a" {
   source = "../../"
 
-  enabled         = true
   create_iam_role = false
 
   cluster_name  = aws_eks_cluster.cluster.id
@@ -158,7 +157,6 @@ module "eks-node-group-a" {
 module "eks-node-group-b" {
   source = "../../"
 
-  enabled         = true
   create_iam_role = false
 
   cluster_name  = aws_eks_cluster.cluster.id
@@ -186,7 +184,6 @@ module "eks-node-group-b" {
 module "eks-node-group-c" {
   source = "../../"
 
-  enabled         = true
   create_iam_role = false
 
   cluster_name  = aws_eks_cluster.cluster.id

--- a/examples/single-named-node-group/main.tf
+++ b/examples/single-named-node-group/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 #####
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.21.0"
+  version = "2.48.0"
 
   name = "simple-vpc"
 
@@ -46,7 +46,7 @@ resource "aws_eks_cluster" "cluster" {
   enabled_cluster_log_types = []
   name                      = "eks"
   role_arn                  = aws_iam_role.cluster.arn
-  version                   = "1.14"
+  version                   = "1.17"
 
   vpc_config {
     subnet_ids              = flatten([module.vpc.public_subnets, module.vpc.private_subnets])
@@ -94,7 +94,6 @@ module "eks-node-group" {
   node_group_name      = "example-nodegroup"
   node_group_role_name = "example-nodegroup"
 
-  enabled      = true
   cluster_name = aws_eks_cluster.cluster.id
 
   subnet_ids = flatten([module.vpc.private_subnets])

--- a/examples/single-node-group-with-launch-template/userdata.tpl
+++ b/examples/single-node-group-with-launch-template/userdata.tpl
@@ -1,0 +1,17 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+set -ex
+
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+yum install -y amazon-ssm-agent
+systemctl enable amazon-ssm-agent && systemctl start amazon-ssm-agent
+
+/etc/eks/bootstrap.sh ${CLUSTER_NAME} --b64-cluster-ca ${B64_CLUSTER_CA} --apiserver-endpoint ${API_SERVER_URL}
+
+--==MYBOUNDARY==--\

--- a/variables.tf
+++ b/variables.tf
@@ -43,20 +43,20 @@ variable "node_role_arn" {
 
 variable "ami_type" {
   type        = string
-  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Defaults to `AL2_x86_64`. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided"
-  default     = "AL2_x86_64"
+  description = "Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided"
+  default     = null
 }
 
 variable "disk_size" {
   type        = number
   description = "Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided"
-  default     = 20
+  default     = null
 }
 
 variable "instance_types" {
   type        = list(string)
-  description = "Set of instance types associated with the EKS Node Group. Defaults to [\"t3.medium\"]. Terraform will only perform drift detection if a configuration value is provided"
-  default     = ["t3.medium"]
+  description = "List of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided"
+  default     = null
 }
 
 variable "kubernetes_labels" {
@@ -83,12 +83,6 @@ variable "source_security_group_ids" {
   description = "Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0)"
 }
 
-variable "enabled" {
-  type        = bool
-  description = "Whether to create the resources. Set to `false` to prevent the module from creating any resources"
-  default     = true
-}
-
 variable "create_iam_role" {
   type        = bool
   description = "Create IAM role for node group. Set to false if pass `node_role_arn` as an argument"
@@ -111,4 +105,10 @@ variable "force_update_version" {
   type        = bool
   description = "Force version update if existing pods are unable to be drained due to a pod disruption budget issue."
   default     = false
+}
+
+variable "launch_template" {
+  type        = map(string)
+  description = "Configuration block with Launch Template settings. `name`, `id` and `version` parameters are available."
+  default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = ">= 2.63, < 4.0"
+    aws = ">= 3.3, < 4.0"
   }
 }


### PR DESCRIPTION
# Description

- Add support for launch templates
- Fully support terraform 0.13
- Remove enabled variable: count or for_each can be used with terraform 0.13
- Add example with working launch template configuration
- Upgrade minimum required version of terraform aws provider
- Update docs

This PR forms major release `3.0.0` of this module