### PR TITLE
Upgrade module to support taints and node group name prefix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v4.0.1
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.45.0
+  rev: v1.50.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- Upgrade module to support tains and node group name prefix
+
+
+<a name="3.1.0"></a>
+## [3.1.0] - 2020-12-02
+
+- Add support for capacity_type ([#9](https://github.com/umotif-public/terraform-aws-eks-node-group/issues/9))
+
+
+<a name="3.0.1"></a>
+## [3.0.1] - 2020-11-09
+
+- Update module to remove 0.14 limit ([#8](https://github.com/umotif-public/terraform-aws-eks-node-group/issues/8))
+- Update changelog
 
 
 <a name="3.0.0"></a>
@@ -52,7 +66,9 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/3.0.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/3.1.0...HEAD
+[3.1.0]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/3.0.1...3.1.0
+[3.0.1]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/2.0.1...3.0.0
 [2.0.1]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/umotif-public/terraform-aws-eks-node-group/compare/1.0.3...2.0.0

--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ This module will create EKS managed Node Group that will join your existing Kube
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v3.0`. Submit pull-requests to `master` branch.
+Terraform 0.12. Pin module version to `~> v4.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
 ```hcl
 module "eks-node-group" {
   source = "umotif-public/eks-node-group/aws"
-  version = "~> 3.0.0"
+  version = "~> 4.0.0"
 
   cluster_name = aws_eks_cluster.cluster.id
+
+  node_group_name_prefix = "eks-test-"
 
   subnet_ids = ["subnet-1","subnet-2","subnet-3"]
 
@@ -29,9 +31,22 @@ module "eks-node-group" {
 
   ec2_ssh_key = "eks-test"
 
-  kubernetes_labels = {
+  labels = {
     lifecycle = "OnDemand"
   }
+
+  taints = [
+    {
+      key    = "test-1"
+      value  = null
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = "test-2"
+      value  = "value-test"
+      effect = "NO_EXECUTE"
+    }
+  ]
 
   force_update_version = true
 
@@ -40,10 +55,6 @@ module "eks-node-group" {
   }
 }
 ```
-
-## Assumptions
-
-Module is to be used with Terraform > 0.13. Fully working with Terraform 0.12 as well.
 
 ## Examples
 
@@ -61,50 +72,66 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 3.19 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.19 |
-| random | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eks_node_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
+| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.main_AmazonEC2ContainerRegistryReadOnly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.main_AmazonEKSWorkerNodePolicy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.main_AmazonEKS_CNI_Policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [random_id.main](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| ami\_release\_version | AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version | `string` | `null` | no |
-| ami\_type | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |
-| capacity\_type | Type of capacity associated with the EKS Node Group. Defaults to ON\_DEMAND. Valid values: ON\_DEMAND, SPOT. | `string` | `"ON_DEMAND"` | no |
-| cluster\_name | The name of the EKS cluster | `string` | n/a | yes |
-| create\_iam\_role | Create IAM role for node group. Set to false if pass `node_role_arn` as an argument | `bool` | `true` | no |
-| desired\_size | Desired number of worker nodes | `number` | n/a | yes |
-| disk\_size | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | `number` | `null` | no |
-| ec2\_ssh\_key | SSH key name that should be used to access the worker nodes | `string` | `null` | no |
-| force\_update\_version | Force version update if existing pods are unable to be drained due to a pod disruption budget issue. | `bool` | `false` | no |
-| instance\_types | List of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided | `list(string)` | `null` | no |
-| kubernetes\_labels | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | `map(string)` | `{}` | no |
-| kubernetes\_version | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |
-| launch\_template | Configuration block with Launch Template settings. `name`, `id` and `version` parameters are available. | `map(string)` | `{}` | no |
-| max\_size | Maximum number of worker nodes | `number` | n/a | yes |
-| min\_size | Minimum number of worker nodes | `number` | n/a | yes |
-| node\_group\_name | The name of the cluster node group. Defaults to <cluster\_name>-<random value> | `string` | `""` | no |
-| node\_group\_role\_name | The name of the cluster node group role. Defaults to <cluster\_name>-managed-group-node | `string` | `""` | no |
-| node\_role\_arn | IAM role arn that will be used by managed node group | `string` | `""` | no |
-| source\_security\_group\_ids | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | `list(string)` | `[]` | no |
-| subnet\_ids | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
-| tags | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
+| <a name="input_ami_release_version"></a> [ami\_release\_version](#input\_ami\_release\_version) | AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version | `string` | `null` | no |
+| <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. Valid values: `AL2_x86_64`, `AL2_x86_64_GPU`. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |
+| <a name="input_capacity_type"></a> [capacity\_type](#input\_capacity\_type) | Type of capacity associated with the EKS Node Group. Defaults to ON\_DEMAND. Valid values: ON\_DEMAND, SPOT. | `string` | `"ON_DEMAND"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Create IAM role for node group. Set to false if pass `node_role_arn` as an argument | `bool` | `true` | no |
+| <a name="input_desired_size"></a> [desired\_size](#input\_desired\_size) | Desired number of worker nodes | `number` | n/a | yes |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Disk size in GiB for worker nodes. Defaults to 20. Terraform will only perform drift detection if a configuration value is provided | `number` | `null` | no |
+| <a name="input_ec2_ssh_key"></a> [ec2\_ssh\_key](#input\_ec2\_ssh\_key) | SSH key name that should be used to access the worker nodes | `string` | `null` | no |
+| <a name="input_force_update_version"></a> [force\_update\_version](#input\_force\_update\_version) | Force version update if existing pods are unable to be drained due to a pod disruption budget issue. | `bool` | `false` | no |
+| <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | List of instance types associated with the EKS Node Group. Terraform will only perform drift detection if a configuration value is provided | `list(string)` | `null` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | `map(string)` | `{}` | no |
+| <a name="input_launch_template"></a> [launch\_template](#input\_launch\_template) | Configuration block with Launch Template settings. `name`, `id` and `version` parameters are available. | `map(string)` | `{}` | no |
+| <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of worker nodes | `number` | n/a | yes |
+| <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum number of worker nodes | `number` | n/a | yes |
+| <a name="input_node_group_name"></a> [node\_group\_name](#input\_node\_group\_name) | The name of the cluster node group. Defaults to <cluster\_name>-<random value> | `string` | `null` | no |
+| <a name="input_node_group_name_prefix"></a> [node\_group\_name\_prefix](#input\_node\_group\_name\_prefix) | Creates a unique name beginning with the specified prefix. Conflicts with node\_group\_name | `string` | `null` | no |
+| <a name="input_node_group_role_name"></a> [node\_group\_role\_name](#input\_node\_group\_role\_name) | The name of the cluster node group role. Defaults to <cluster\_name>-managed-group-node | `string` | `""` | no |
+| <a name="input_node_role_arn"></a> [node\_role\_arn](#input\_node\_role\_arn) | IAM role arn that will be used by managed node group | `string` | `""` | no |
+| <a name="input_source_security_group_ids"></a> [source\_security\_group\_ids](#input\_source\_security\_group\_ids) | Set of EC2 Security Group IDs to allow SSH access (port 22) from on the worker nodes. If you specify `ec2_ssh_key`, but do not specify this configuration when you create an EKS Node Group, port 22 on the worker nodes is opened to the Internet (0.0.0.0/0) | `list(string)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
+| <a name="input_taints"></a> [taints](#input\_taints) | List of objects containing Kubernetes taints which will be applied to the nodes in the node group. Maximum of 50 taints per node group. | `list(object({ key = string, value = any, effect = string }))` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| iam\_role\_arn | IAM role ARN used by node group. |
-| iam\_role\_id | IAM role ID used by node group. |
-| node\_group | Outputs from EKS node group. See `aws_eks_node_group` Terraform documentation for values |
-
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | IAM role ARN used by node group. |
+| <a name="output_iam_role_id"></a> [iam\_role\_id](#output\_iam\_role\_id) | IAM role ID used by node group. |
+| <a name="output_node_group"></a> [node\_group](#output\_node\_group) | Outputs from EKS node group. See `aws_eks_node_group` Terraform documentation for values |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/examples/single-named-node-group/main.tf
+++ b/examples/single-named-node-group/main.tf
@@ -5,51 +5,25 @@ provider "aws" {
 #####
 # VPC and subnets
 #####
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+data "aws_vpc" "default" {
+  default = true
+}
 
-  name = "simple-vpc"
-
-  cidr = "10.0.0.0/16"
-
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  private_subnet_tags = {
-    "kubernetes.io/role/internal-elb" = "1"
-  }
-
-  public_subnet_tags = {
-    "kubernetes.io/role/elb" = "1"
-  }
-
-  enable_dns_hostnames   = true
-  enable_dns_support     = true
-  enable_nat_gateway     = true
-  enable_vpn_gateway     = true
-  single_nat_gateway     = true
-  one_nat_gateway_per_az = false
-
-  tags = {
-    "kubernetes.io/cluster/eks" = "shared",
-    Environment                 = "test"
-  }
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
 }
 
 #####
 # EKS Cluster
 #####
-
 resource "aws_eks_cluster" "cluster" {
   enabled_cluster_log_types = []
-  name                      = "eks"
+  name                      = "eks-module-test-cluster"
   role_arn                  = aws_iam_role.cluster.arn
-  version                   = "1.18"
+  version                   = "1.20"
 
   vpc_config {
-    subnet_ids              = flatten([module.vpc.public_subnets, module.vpc.private_subnets])
+    subnet_ids              = data.aws_subnet_ids.all.ids
     security_group_ids      = []
     endpoint_private_access = "true"
     endpoint_public_access  = "true"
@@ -96,7 +70,7 @@ module "eks-node-group" {
 
   cluster_name = aws_eks_cluster.cluster.id
 
-  subnet_ids = flatten([module.vpc.private_subnets])
+  subnet_ids = data.aws_subnet_ids.all.ids
 
   desired_size = 1
   min_size     = 1
@@ -104,7 +78,20 @@ module "eks-node-group" {
 
   ec2_ssh_key = "eks-test"
 
-  kubernetes_labels = {
+  taints = [
+    {
+      key    = "test-1"
+      value  = null
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = "test-2"
+      value  = "value-test"
+      effect = "NO_EXECUTE"
+    }
+  ]
+
+  labels = {
     lifecycle = "OnDemand"
   }
 

--- a/examples/single-node-group-with-launch-template/main.tf
+++ b/examples/single-node-group-with-launch-template/main.tf
@@ -5,51 +5,25 @@ provider "aws" {
 #####
 # VPC and subnets
 #####
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+data "aws_vpc" "default" {
+  default = true
+}
 
-  name = "simple-vpc"
-
-  cidr = "10.0.0.0/16"
-
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  private_subnet_tags = {
-    "kubernetes.io/role/internal-elb" = "1"
-  }
-
-  public_subnet_tags = {
-    "kubernetes.io/role/elb" = "1"
-  }
-
-  enable_dns_hostnames   = true
-  enable_dns_support     = true
-  enable_nat_gateway     = true
-  enable_vpn_gateway     = true
-  single_nat_gateway     = true
-  one_nat_gateway_per_az = false
-
-  tags = {
-    "kubernetes.io/cluster/eks" = "shared",
-    Environment                 = "test"
-  }
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
 }
 
 #####
 # EKS Cluster
 #####
-
 resource "aws_eks_cluster" "cluster" {
   enabled_cluster_log_types = []
-  name                      = "eks"
+  name                      = "eks-module-test-cluster"
   role_arn                  = aws_iam_role.cluster.arn
-  version                   = "1.18"
+  version                   = "1.20"
 
   vpc_config {
-    subnet_ids              = flatten([module.vpc.public_subnets, module.vpc.private_subnets])
+    subnet_ids              = data.aws_subnet_ids.all.ids
     security_group_ids      = []
     endpoint_private_access = "true"
     endpoint_public_access  = "true"
@@ -134,7 +108,7 @@ module "eks-node-group" {
 
   cluster_name = aws_eks_cluster.cluster.id
 
-  subnet_ids = flatten([module.vpc.private_subnets])
+  subnet_ids = data.aws_subnet_ids.all.ids
 
   desired_size = 1
   min_size     = 1
@@ -145,7 +119,7 @@ module "eks-node-group" {
     version = data.aws_launch_template.cluster.latest_version
   }
 
-  kubernetes_labels = {
+  labels = {
     lifecycle = "OnDemand"
   }
 

--- a/examples/single-node-group/main.tf
+++ b/examples/single-node-group/main.tf
@@ -5,51 +5,25 @@ provider "aws" {
 #####
 # VPC and subnets
 #####
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+data "aws_vpc" "default" {
+  default = true
+}
 
-  name = "simple-vpc"
-
-  cidr = "10.0.0.0/16"
-
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  private_subnet_tags = {
-    "kubernetes.io/role/internal-elb" = "1"
-  }
-
-  public_subnet_tags = {
-    "kubernetes.io/role/elb" = "1"
-  }
-
-  enable_dns_hostnames   = true
-  enable_dns_support     = true
-  enable_nat_gateway     = true
-  enable_vpn_gateway     = true
-  single_nat_gateway     = true
-  one_nat_gateway_per_az = false
-
-  tags = {
-    "kubernetes.io/cluster/eks" = "shared",
-    Environment                 = "test"
-  }
+data "aws_subnet_ids" "all" {
+  vpc_id = data.aws_vpc.default.id
 }
 
 #####
 # EKS Cluster
 #####
-
 resource "aws_eks_cluster" "cluster" {
   enabled_cluster_log_types = []
-  name                      = "eks"
+  name                      = "eks-module-test-cluster"
   role_arn                  = aws_iam_role.cluster.arn
-  version                   = "1.18"
+  version                   = "1.20"
 
   vpc_config {
-    subnet_ids              = flatten([module.vpc.public_subnets, module.vpc.private_subnets])
+    subnet_ids              = data.aws_subnet_ids.all.ids
     security_group_ids      = []
     endpoint_private_access = "true"
     endpoint_public_access  = "true"
@@ -93,10 +67,10 @@ module "eks-node-group" {
 
   cluster_name = aws_eks_cluster.cluster.id
 
-  subnet_ids = flatten([module.vpc.private_subnets])
+  subnet_ids = data.aws_subnet_ids.all.ids
 
   desired_size = 2
-  min_size     = 2
+  min_size     = 1
   max_size     = 2
 
   capacity_type  = "SPOT"
@@ -104,7 +78,25 @@ module "eks-node-group" {
 
   ec2_ssh_key = "eks-test"
 
-  kubernetes_labels = {
+  taints = [
+    {
+      key    = "test-1"
+      value  = null
+      effect = "NO_SCHEDULE"
+    },
+    {
+      key    = "test-2"
+      value  = "value-test"
+      effect = "NO_EXECUTE"
+    },
+    {
+      key    = "test-3"
+      value  = "value-test-3"
+      effect = "PREFER_NO_SCHEDULE"
+    }
+  ]
+
+  labels = {
     lifecycle = "SPOT"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "instance_types" {
   default     = null
 }
 
-variable "kubernetes_labels" {
+variable "labels" {
   type        = map(string)
   description = "Key-value mapping of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed"
   default     = {}
@@ -92,7 +92,13 @@ variable "create_iam_role" {
 variable "node_group_name" {
   type        = string
   description = "The name of the cluster node group. Defaults to <cluster_name>-<random value>"
-  default     = ""
+  default     = null
+}
+
+variable "node_group_name_prefix" {
+  type        = string
+  description = "Creates a unique name beginning with the specified prefix. Conflicts with node_group_name"
+  default     = null
 }
 
 variable "node_group_role_name" {
@@ -117,4 +123,10 @@ variable "capacity_type" {
   type        = string
   description = "Type of capacity associated with the EKS Node Group. Defaults to ON_DEMAND. Valid values: ON_DEMAND, SPOT."
   default     = "ON_DEMAND"
+}
+
+variable "taints" {
+  type        = list(object({ key = string, value = any, effect = string }))
+  description = "List of objects containing Kubernetes taints which will be applied to the nodes in the node group. Maximum of 50 taints per node group."
+  default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 3.19"
+    aws = ">= 3.43"
   }
 }


### PR DESCRIPTION
# Description

- minimum aws provider set to 3.43.0
- support taints
- support node group name prefix
- update logic
- update examples
- rename variable `kubernetes_labels` to `labels`
- resolves issue #10 